### PR TITLE
add service protocol

### DIFF
--- a/Sources/Service/Service.swift
+++ b/Sources/Service/Service.swift
@@ -1,0 +1,7 @@
+/// Empty protocol for declaring types that can
+/// be registered as a service.
+///
+/// This protocol allows the Service package to prevent
+/// ambiguous service registration, i.e., preventing closures
+/// that yield a service from being registered _as_ a service.
+public protocol Service {}

--- a/Sources/Service/Services.swift
+++ b/Sources/Service/Services.swift
@@ -20,7 +20,7 @@ extension Services {
         tag: String? = nil,
         isSingleton: Bool = false,
         factory: @escaping (Container) throws -> (S)
-    ) {
+    ) where S: Service {
         let factory = BasicServiceFactory(
             S.self,
             tag: tag,
@@ -38,7 +38,7 @@ extension Services {
         tag: String? = nil,
         isSingleton: Bool = false,
         factory: @escaping (Container) throws -> (S)
-    ) {
+    ) where S: Service {
         let factory = BasicServiceFactory(
             S.self,
             tag: tag,
@@ -63,7 +63,7 @@ extension Services {
     }
 
     /// Adds a service type to the Services.
-    public mutating func register<S: ServiceType>(_ type: S.Type = S.self) {
+    public mutating func register<S>(_ type: S.Type = S.self) where S: ServiceType {
         let factory = TypeServiceFactory(S.self)
         self.register(factory)
     }
@@ -73,7 +73,7 @@ extension Services {
 
 extension Services {
     /// Adds an initialized provider
-    public mutating func register<P: Provider>(_ provider: P) throws {
+    public mutating func register<P>(_ provider: P) throws where P: Provider {
         guard !providers.contains(where: { Swift.type(of: $0) == P.self }) else {
             return
         }
@@ -86,22 +86,22 @@ extension Services {
 
 extension Services {
     /// Adds an instance of a service to the Services.
-    public mutating func use<S>(
+    public mutating func register<S>(
         _ instance: S,
         as interface: Any.Type,
         tag: String? = nil,
         isSingleton: Bool = false
-    ) {
-        return self.use(instance, as: [interface], tag: tag, isSingleton: isSingleton)
+    ) where S: Service {
+        return self.register(instance, as: [interface], tag: tag, isSingleton: isSingleton)
     }
 
     /// Adds an instance of a service to the Services.
-    public mutating func use<S>(
+    public mutating func register<S>(
         _ instance: S,
         as supports: [Any.Type] = [],
         tag: String? = nil,
         isSingleton: Bool = false
-    ) {
+    ) where S: Service {
         let factory = BasicServiceFactory(
             S.self,
             tag: tag,

--- a/Tests/ServiceTests/ConfigTests.swift
+++ b/Tests/ServiceTests/ConfigTests.swift
@@ -12,7 +12,7 @@ class ConfigTests: XCTestCase {
         services.register(BCryptHasher.self)
 
         let bcryptConfig = BCryptConfig(cost: 4)
-        services.use(bcryptConfig)
+        services.register(bcryptConfig)
 
         let container = BasicContainer(
             config: config,
@@ -71,9 +71,9 @@ class ConfigTests: XCTestCase {
         services.register(BCryptHasher.self)
 
         let bcryptConfig4 = BCryptConfig(cost: 4)
-        services.use(bcryptConfig4)
+        services.register(bcryptConfig4)
         let bcryptConfig5 = BCryptConfig(cost: 5)
-        services.use(bcryptConfig5)
+        services.register(bcryptConfig5)
 
         let container = BasicContainer(
             config: config,

--- a/Tests/ServiceTests/ServiceTests.swift
+++ b/Tests/ServiceTests/ServiceTests.swift
@@ -46,7 +46,7 @@ class ServiceTests: XCTestCase {
         services.register(AllCapsLog.self)
 
         let foo = PrintLog()
-        services.use(foo, as: Log.self, tag: "foo")
+        services.register(foo, as: Log.self, tag: "foo")
 
         let container = BasicContainer(
             config: config,

--- a/Tests/ServiceTests/Utilities.swift
+++ b/Tests/ServiceTests/Utilities.swift
@@ -7,7 +7,7 @@ protocol Log {
     func log(_ string: String)
 }
 
-class PrintLog: Log {
+class PrintLog: Log, Service {
     func log(_ string: String) {
         print("[Print Log] \(string)")
     }
@@ -37,7 +37,7 @@ extension AllCapsLog: ServiceType {
 }
 
 
-class ConfigurableLog: Log {
+class ConfigurableLog: Log, Service {
     let myConfig: String
     
     init(config: String) { self.myConfig = config }
@@ -92,7 +92,7 @@ extension BCryptHasher: ServiceType {
 
 
 
-struct BCryptConfig {
+struct BCryptConfig: Service {
     let cost: Int
     init(cost: Int) {
         self.cost = cost


### PR DESCRIPTION
fixes https://github.com/vapor/vapor/issues/1404

adds a `Service` protocol that allows us to disambiguate calls to `.register`. This allows us to undo the change to `.use` and have all calls on service be `.register`. 
  