### PR TITLE
Singletons implementation cleanup

### DIFF
--- a/Sources/Service/ServiceCacheable.swift
+++ b/Sources/Service/ServiceCacheable.swift
@@ -47,25 +47,27 @@ public final class ServiceCache {
 
     /// Gets the cached service if it is a singleton.
     /// - throws if the service was cached as an error
-    internal func getSingleton(
-        _ service: Any.Type
-    ) throws -> Any? {
+    internal func getSingleton<Interface>(
+        _ service: Interface.Type
+    ) throws -> Interface? {
         let key = InterfaceIdentifier(interface: service)
         guard let resolved = singletons[key] else {
             return nil
         }
+        let result = try resolved.resolve() as! Interface
 
-        return try resolved.resolve()
+        return result
     }
 
     /// internal method for setting cache based on ResolvedService enum.
-    internal func setSingleton(
+    internal func setSingleton<Interface>(
         _ resolved: ResolvedService,
-        type serviceType: Any.Type
+        type serviceType: Interface.Type
     ) {
         let key = InterfaceIdentifier(interface: serviceType)
         singletons[key] = resolved
     }
+    
 }
 
 /// a resolved service, either error or the service
@@ -93,8 +95,8 @@ internal struct InterfaceIdentifier: Hashable, CustomDebugStringConvertible {
 
     private let interface: ObjectIdentifier
 
-    public init(interface: Any.Type) {
-        self.interface = ObjectIdentifier(interface)
+    public init<Interface>(interface: Interface.Type) {
+        self.interface = ObjectIdentifier(Interface.self)
         self.hashValue = self.interface.hashValue
         self.debugDescription = "ServiceIdentifier(\(interface))"
     }

--- a/Sources/Service/Services.swift
+++ b/Sources/Service/Services.swift
@@ -54,8 +54,14 @@ extension Services {
     public mutating func register(_ factory: ServiceFactory) {
         if let existing = factories.index(where: {
             $0.serviceType == factory.serviceType &&
-                $0.serviceTag == factory.serviceTag
+            $0.serviceTag == factory.serviceTag
         }) {
+            //print("WARNING: The \(factory.serviceType):\(factory.serviceTag ?? "any") service has been registered more than once. Only the last registration counts.")
+            
+            if factories[existing].serviceIsSingleton != factory.serviceIsSingleton {
+                print("WARNING: You have registered the \(factory.serviceType) service both as singleton and as instanced. Only the last registration counts. This probably isn't what you wanted!")
+            }
+            
             factories[existing] = factory
         } else {
             factories.append(factory)

--- a/Tests/ServiceTests/ServiceTests.swift
+++ b/Tests/ServiceTests/ServiceTests.swift
@@ -141,6 +141,30 @@ class ServiceTests: XCTestCase {
         )
         XCTAssertThrowsError(_ = try container.make(Log.self, for: ServiceTests.self), "Should not have resolved")
     }
+    
+    func testSingletonHandling() throws {
+        let config = Config()
+        var services = Services()
+        
+        services.register(isSingleton: true) { _ in PrintLog() }
+        services.register { _ in ConfigurableLog(config: "whatever") }
+        services.register { _ in NotAClassService() }
+        
+        let container = try BasicContainer(config: config, environment: .production, services: services, on: DefaultEventLoop(label: "unit-test"))
+
+        let printLog1 = try container.make(PrintLog.self, for: ServiceTests.self)
+        let printLog2 = try container.make(PrintLog.self, for: BasicContainer.self)
+        let configLog1 = try container.make(ConfigurableLog.self, for: ServiceTests.self)
+        let configLog2 = try container.make(ConfigurableLog.self, for: BasicContainer.self)
+        let notClass1 = try container.make(NotAClassService.self, for: ServiceTests.self)
+        let notClass2 = try container.make(NotAClassService.self, for: BasicContainer.self)
+
+        XCTAssertEqual(ObjectIdentifier(printLog1), ObjectIdentifier(printLog2), "Singleton service must give the same object for different clients")
+        XCTAssertNotEqual(ObjectIdentifier(configLog1), ObjectIdentifier(configLog2), "Instance service must NOT give the same object for different clients")
+        XCTAssertNotEqual(notClass1.counter, notClass2.counter, "Struct service must NOT return the same struct for different clients")
+
+        print(container.serviceCache.debugDescription)
+    }
 
     static var allTests = [
         ("testHappyPath", testHappyPath),
@@ -151,6 +175,7 @@ class ServiceTests: XCTestCase {
         ("testSpecific", testSpecific),
         ("testProvider", testProvider),
         ("testRequire", testRequire),
+        ("testSingletonHandling", testSingletonHandling),
     ]
 }
 

--- a/Tests/ServiceTests/Utilities.swift
+++ b/Tests/ServiceTests/Utilities.swift
@@ -56,6 +56,14 @@ class AllCapsProvider: Provider {
     func boot(_ container: Container) throws { }
 }
 
+struct NotAClassService: Service {
+    static private var counter = 0
+    
+    let counter: Int = { NotAClassService.counter += 1; return NotAClassService.counter }()
+}
+
+class MoreOfAClassService: Service {}
+
 // MARK: BCrypt
 
 protocol Hasher {


### PR DESCRIPTION
These are some minor changes to improve debugging and tweak performance characteristics (I haven't tested the latter at all, though). A notable difference is that singletons are no longer recorded in `ServiceCache`'s main `services` dictionary, which was an unnecessary duplication (a singleton would get one entry in `services` for each client type that requested it, even though there was only ever one instance - this could get memory-expensive for singleton services implemented as value types).