### PR TITLE
Adding get with default value

### DIFF
--- a/Sources/Service/Environment.swift
+++ b/Sources/Service/Environment.swift
@@ -49,6 +49,11 @@ extension Environment: Equatable {
 extension Environment {
     /// Gets a key from the process environment
     public static func get(_ key: String) -> String? {
-         return ProcessInfo.processInfo.environment[key]
+        return ProcessInfo.processInfo.environment[key]
+    }
+    
+    /// Gets a key from the process environment with default value
+    public static func get(_ key: String, default defaultValue: String) -> String {
+        return get(key) ?? defaultValue
     }
 }


### PR DESCRIPTION
When configuring my environment, doing a default value fallback is the most common repeating code in my app ... thought this could help other people keep their apps clean of loads of guards and `??`