### PR TITLE
add ServiceProvider.willShutdown(_:)

### DIFF
--- a/Sources/ServiceKit/Provider/ServiceProvider.swift
+++ b/Sources/ServiceKit/Provider/ServiceProvider.swift
@@ -41,16 +41,26 @@ public protocol ServiceProvider {
 
     /// Called after the container has fully initialized and after `willBoot(_:)`.
     func didBoot(_ c: Container) throws -> EventLoopFuture<Void>
+    
+    /// Called before the container shuts down.
+    func willShutdown(_ c: Container) throws -> EventLoopFuture<Void>
 }
 
 extension ServiceProvider {
-    /// See `Provider`.
-    public func willBoot(_ container: Container) throws -> EventLoopFuture<Void> {
-        return container.eventLoop.makeSucceededFuture(())
+    /// Default implementation.
+    public func willBoot(_ c: Container) throws -> EventLoopFuture<Void> {
+        return c.eventLoop.makeSucceededFuture(())
     }
     
-    /// See `Provider`.
-    public func didBoot(_ container: Container) throws -> EventLoopFuture<Void> {
-        return container.eventLoop.makeSucceededFuture(())
+    /// Default implementation.
+    public func didBoot(_ c: Container) throws -> EventLoopFuture<Void> {
+        return c.eventLoop.makeSucceededFuture(())
+    }
+    
+    /// Default implementation.
+    public func willShutdown(_ c: Container) throws -> EventLoopFuture<Void> {
+        return c.eventLoop.makeSucceededFuture(())
     }
 }
+
+#warning("TODO: consider moving to vapor and removing EL from container")


### PR DESCRIPTION
As part of https://github.com/vapor/vapor/issues/1889, this PR adds support for a new `willShutdown` hook on service providers. 

This hook will give service providers a chance to do asynchronous cleanup on containers that are about to deinitialize.

While adding this, I noticed that it could make sense to move `ServiceProvider` into Vapor. This protocol is the only dependency `ServiceKit` has on NIO (because its methods are async). If we moved it, we could allow `ServiceKit` to have no dependencies and be viable as a service locator framework for non-server use cases.

I've added a TODO item to explore this more in the future. Until then, we can continue working toward graceful shutdown with this new method.